### PR TITLE
feat: ゲームラウンド数を4Rか8Rで選択可能に

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,7 +39,9 @@
       "Bash(git --version:*)",
       "Bash(git init:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "Bash(git rebase:*)",
+      "Bash(GIT_EDITOR=true git rebase:*)"
     ]
   }
 }

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ NUM_DECKS = 2                      # 2デッキ = 48カード (6ランク×4ス�
 TRUMP_COUNT = 4                    # 切り札4枚
 
 START_GOLD = 5
-WAGE_CURVE = [1, 1, 2, 2, 2, 3]  # 初期ワーカーの給料（6ラウンド対応）
+WAGE_CURVE = [1, 1, 2, 2, 2, 3, 3, 3]  # 初期ワーカーの給料（8R対応）
 # アップグレードワーカーは取得時2金支払い、以後給料なし
 UPGRADE_WORKER_COST = 2  # 取得時コスト
 INITIAL_WORKERS = 2  # 初期ワーカー数
@@ -244,6 +244,7 @@ class GameConfig:
     take_gold_instead: int = TAKE_GOLD_INSTEAD
     rescue_gold_for_4th: int = RESCUE_GOLD_FOR_4TH
     enabled_upgrades: Optional[List[str]] = None  # None = 全アップグレード有効
+    rounds: int = ROUNDS  # ゲームのラウンド数（4 or 8）
 
     def to_dict(self) -> Dict[str, Any]:
         """設定を辞書形式で返す"""
@@ -258,6 +259,7 @@ class GameConfig:
             "take_gold_instead": self.take_gold_instead,
             "rescue_gold_for_4th": self.rescue_gold_for_4th,
             "enabled_upgrades": self.enabled_upgrades,
+            "rounds": self.rounds,
         }
 
 
@@ -2046,6 +2048,7 @@ class GameEngine:
         display_plays = self.trick_plays if self.trick_plays else self.last_trick_plays
         return {
             "round_no": self.round_no,
+            "rounds": self.config.rounds,
             "phase": self.phase,
             "sub_phase": self.sub_phase,
             "players": snapshot_players(self.players),

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -486,10 +486,18 @@ with st.sidebar:
             "enabled_upgrades": DEFAULT_ENABLED_UPGRADES[:],
         }
 
-    # ゲームモード表示（6ラウンド固定）
-    st.subheader("🎮 ゲームモード")
-    st.info(f"📅 {ROUNDS}ラウンド（スタンダード）")
-    st.session_state.game_config["rounds"] = ROUNDS
+    with st.expander("🎲 ゲームモード", expanded=False):
+        rounds_options = [4, 6, 8]
+        current_rounds = st.session_state.game_config.get("rounds", ROUNDS)
+        rounds_index = rounds_options.index(current_rounds) if current_rounds in rounds_options else 1
+        st.session_state.game_config["rounds"] = st.radio(
+            "ラウンド数",
+            options=rounds_options,
+            index=rounds_index,
+            format_func=lambda x: f"{x}ラウンド（{'ショート' if x == 4 else 'スタンダード' if x == 6 else 'ロング'}）",
+            help="4ラウンド: 短時間プレイ、6ラウンド: スタンダード、8ラウンド: 長期戦略",
+            horizontal=True
+        )
 
     with st.expander("💰 初期リソース", expanded=False):
         st.session_state.game_config["start_gold"] = st.number_input(
@@ -593,8 +601,9 @@ with st.sidebar:
     with st.expander("📋 現在の設定値", expanded=False):
         config = st.session_state.game_config
         enabled_count = len(config.get("enabled_upgrades", ALL_UPGRADES))
+        rounds_setting = config.get("rounds", ROUNDS)
         st.markdown(f"""
-        - **ゲームモード**: {ROUNDS}ラウンド（スタンダード）
+        - **ラウンド数**: {rounds_setting}R（{'ショート' if rounds_setting == 4 else 'スタンダード' if rounds_setting == 6 else 'ロング'}）
         - **初期金貨**: {config['start_gold']}G
         - **初期ワーカー**: {config['initial_workers']}人
         - **宣言ボーナス**: +{config['declaration_bonus_vp']}VP
@@ -632,6 +641,7 @@ def init_game():
             take_gold_instead=cfg["take_gold_instead"],
             rescue_gold_for_4th=cfg["rescue_gold_for_4th"],
             enabled_upgrades=enabled,
+            rounds=cfg.get("rounds", ROUNDS),
         )
     else:
         config = GameConfig()


### PR DESCRIPTION
設定画面に「ゲームモード」セクションを追加し、ラウンド数を選択可能に。
8ラウンド対応のため給料カーブも拡張。