### PR TITLE
feat: 切り札を4枚に削減、ランク要素を削除

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -595,7 +595,7 @@ def parse_card(s: str) -> Card:
 def card_display(card: Card) -> str:
     """Return formatted display string for a card with emoji."""
     if card.is_trump():
-        return f"🌟{card.rank}"
+        return "🌟切り札"  # ランクなし
     suit_emoji = {"Spade": "♠", "Heart": "♥", "Diamond": "♦", "Club": "♣"}
     return f"{suit_emoji[card.suit]}{card.rank}"
 
@@ -776,7 +776,7 @@ if pending is not None:
         lead = context["lead_card"]
         if lead:
             if lead.is_trump():
-                st.info(f"🌟 リード: 切り札{lead.rank}")
+                st.info("🌟 リード: 切り札")
             else:
                 suit_emoji = {"Spade": "♠", "Heart": "♥", "Diamond": "♦", "Club": "♣"}
                 st.info(f"{suit_emoji.get(lead.suit, '')} リード: {lead.suit}（マストフォロー）")


### PR DESCRIPTION
- 切り札を8枚(T1〜T4 x2)から4枚(ランクなし)に変更
- 切り札が複数出た場合、最初に出したプレイヤー(リーダーに近い)が勝利
- 表示を「🌟切り札」に統一(数字を削除)