### PR TITLE
feat: ゲームバランス調整 - 6R固定、手札5枚、魔女R3限定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,17 +20,18 @@ python main.py
 
 ### Core Game Loop (`main.py`)
 
-The game runs 4 rounds, each with these phases:
+The game runs 6 rounds, each with these phases:
 
-1. **Upgrade Reveal** - Random upgrades revealed for drafting
-2. **Trick-Taking Phase**
-   - Players see 6 cards, declare target tricks (0-4)
-   - Seal 2 cards (unplayable), play 4 tricks with remaining 4 cards
-   - No trump suit; must follow lead suit if able
+1. **Card Deal** - Deck reshuffled each round (48 cards + 4 trumps)
+2. **Upgrade Reveal** - Upgrades revealed (Round 3 shows witches instead)
+3. **Trick-Taking Phase**
+   - Players see 5 cards, declare target tricks (0-4)
+   - Seal 1 card (unplayable), play 4 tricks with remaining 4 cards
+   - Trump cards can win any trick; must follow lead suit if able
    - Declaration bonus (+1 VP) for matching predicted tricks
-3. **Upgrade Selection** - Players ranked by tricks won pick upgrades or take gold
-4. **Worker Placement** - Assign workers to TRADE/HUNT/RECRUIT actions
-5. **Wage Payment** - Pay workers, tiered debt penalty (max -3 VP)
+4. **Upgrade Selection** - Players ranked by tricks won pick upgrades or take gold
+5. **Worker Placement** - Assign workers to TRADE/HUNT/RECRUIT actions
+6. **Wage Payment** - Pay initial workers only (hired workers paid 2G upfront, no wages)
 
 ### Key Data Structures
 
@@ -40,13 +41,16 @@ The game runs 4 rounds, each with these phases:
 
 ### Game Configuration (constants at top of file)
 
-- `ROUNDS = 4`, `TRICKS_PER_ROUND = 4`, `CARDS_PER_SET = 6`
-- `WAGE_CURVE = [1, 1, 2, 2]` - Initial worker wages per round
-- `UPGRADED_WAGE_CURVE = [1, 2, 3, 4]` - Hired worker wages per round
-- `START_GOLD = 5`
+- `ROUNDS = 6`, `TRICKS_PER_ROUND = 4`, `CARDS_PER_SET = 5`
+- `NUM_DECKS = 2` - 2 decks (48 cards = 6 ranks × 4 suits × 2)
+- `WAGE_CURVE = [1, 1, 2, 2, 2, 3]` - Initial worker wages per round
+- `UPGRADE_WORKER_COST = 2` - Cost to hire workers (no wages after)
+- `START_GOLD = 7`
 - `DECLARATION_BONUS_VP = 1` (no failure penalty)
-- `DEBT_PENALTY_MULTIPLIER = 3` - VP penalty per 1 gold debt (default: 3)
-- `DEBT_PENALTY_CAP = None` - Max penalty cap (None = unlimited)
+- `DEBT_PENALTY_MULTIPLIER = 2` - VP penalty per 1 gold debt
+- `WITCH_ROUND = 2` - Witches appear in round 3 (0-indexed)
+- Trade upgrade: +2 gold/level (base 2, Lv1=4, Lv2=6)
+- Hunt upgrade: +1 VP/level (base 1, Lv1=2, Lv2=3)
 
 ### Bot Logic
 
@@ -55,8 +59,8 @@ Bots use simple heuristics in `choose_card()`, `declare_tricks()`, `seal_cards()
 ## Card Input Format
 
 When playing as human, enter cards as `{suit}{rank}`:
-- S = Spade, H = Heart, D = Diamond, C = Club
-- Examples: `S13` (Spade King), `H07` (Heart 7), `D01` (Diamond Ace)
+- S = Spade, H = Heart, D = Diamond, C = Club, T = Trump
+- Examples: `S06` (Spade 6), `H03` (Heart 3), `D01` (Diamond Ace), `T01` (Trump)
 
 ## Logging
 


### PR DESCRIPTION
## 実装した修正
- ラウンド数: 4R → 6R固定
- 給料カーブ: [1,1,2,2] → [1,1,2,2,2,3]
- アップグレードワーカー: 毎ラウンド給料 → 取得時2金支払い、以後給料なし
- 手札/封印: 6枚/2枚封印 → 5枚/1枚封印
- 交易アップグレード: +1金/レベル → +2金/レベル (基礎2, Lv1=4, Lv2=6)
- 魔女カード: 毎ラウンド公開 → 3ラウンド目のみ公開
- デッキ: 2デッキ（48枚）+ 切り札4枚 = 52枚
- ラウンド毎デッキリシャッフル
- 新魔女《財宝変換の魔女》追加 (ゲーム終了時1金→1VP変換)