### PR TITLE
feat: 宣言0を有効化し、成功時に1恩寵ボーナスを追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -2223,6 +2223,10 @@ class GameEngine:
             if p.tricks_won_this_round == p.declared_tricks:
                 p.vp += bonus_vp
                 self._log(f"宣言成功: {p.name} が {p.declared_tricks} を的中 -> +{bonus_vp} VP")
+                # 宣言0成功で恩寵ボーナス
+                if GRACE_ENABLED and p.declared_tricks == 0:
+                    p.grace_points += GRACE_DECLARATION_ZERO_BONUS
+                    self._log(f"  (宣言0成功ボーナス: +{GRACE_DECLARATION_ZERO_BONUS} 恩寵)")
 
     def _finish_game(self):
         """Finalize game and determine winner."""

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -728,7 +728,7 @@ for row in range(2):
                             st.markdown(f"**{upgrade_name(w)}**")
                             st.write(upgrade_description(w))
             # Show declaration info during trick phase
-            if p.get("declared_tricks", 0) > 0 or p.get("tricks_won", 0) > 0:
+            if "declared_tricks" in p:
                 st.markdown(f"🎯 宣言 {p['declared_tricks']} / 獲得 {p['tricks_won']}")
 
 # Revealed Upgrades display（2列表示でモバイル対応）
@@ -796,8 +796,8 @@ if pending is not None:
         st.divider()
         declared = st.selectbox(
             "何トリック取る？",
-            options=list(range(1, TRICKS_PER_ROUND + 1)),
-            index=1
+            options=list(range(0, TRICKS_PER_ROUND + 1)),
+            index=2
         )
         if st.button("🎯 宣言する", type="primary", use_container_width=True):
             game.provide_input(declared)


### PR DESCRIPTION
- Streamlit版で宣言の選択肢を0-4に拡張（CLI版と整合）
- GameEngineの_apply_declaration_bonusに宣言0成功時の恩寵ボーナス処理を追加
- 宣言0の場合でも宣言情報が正しく表示されるよう条件を修正