### PR TITLE
feat: 財宝変換の魔女を1金→1恩寵に変更

### DIFF
--- a/WITCH_PROPOSALS.md
+++ b/WITCH_PROPOSALS.md
@@ -7,7 +7,7 @@
 | 1 | WITCH_BLACKROAD | 《黒路の魔女》 | TRADEを行うたび+2金 |
 | 2 | WITCH_BLOODHUNT | 《血誓の討伐官》 | HUNTを行うたび+1VP |
 | 3 | WITCH_HERD | 《群導の魔女》 | 雇用ラウンド給料-1 |
-| 4 | WITCH_TREASURE | 《財宝変換の魔女》 | ゲーム終了時1金→1VP |
+| 4 | WITCH_TREASURE | 《財宝変換の魔女》 | ゲーム終了時1金→1恩寵 |
 | 5 | WITCH_BLESSING | 《祈祷の魔女》 | PRAYを行うたび+1恩寵 |
 
 ---


### PR DESCRIPTION
- WITCH_TREASUREの効果を「ゲーム終了時1金→1VP」から 「ゲーム終了時1金→1恩寵」に変更
- 恩寵閾値ボーナス計算前に金→恩寵変換を実行するよう修正
- play_game_cli, GameEngine, シミュレーション関数すべてを更新

シミュレーション結果（1000ゲーム）:
- 変更前: 平均VP 21.5, 勝率 39.9%（最強）
- 変更後: 平均VP 18.8, 勝率 36.1%（3位）