### PR TITLE
feat: 4位ボーナスの恩寵を1→2に強化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ GRACE_DONATE_GAIN = 1             # 寄付獲得量
 GRACE_RITUAL_GAIN = 1             # 儀式アクション獲得量
 GRACE_DECLARATION_ZERO_BONUS = 1  # 宣言0成功ボーナス
 GRACE_ZERO_TRICKS_BONUS = 1       # トリック0勝ボーナス
-GRACE_4TH_PLACE_BONUS = 1         # 4位救済ボーナス
+GRACE_4TH_PLACE_BONUS = 2         # 4位救済ボーナス
 ```
 
 ### Grace Actions (恩寵アクション)

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ GRACE_DECLARATION_ZERO_BONUS = 1
 # 恩寵獲得: トリテ0勝
 GRACE_ZERO_TRICKS_BONUS = 1
 # 4位ボーナス: 恩寵選択時の獲得量
-GRACE_4TH_PLACE_BONUS = 1
+GRACE_4TH_PLACE_BONUS = 2
 # 後出し権: トリック中に順番を最後に変更（1ラウンド1回）
 GRACE_LAST_PLAY_COST = 2
 # 負債軽減: 恩寵消費で負債1を消去


### PR DESCRIPTION
恩寵の価値を高めるため、4位救済ボーナスで恩寵を選択した際の
獲得量を1から2に変更。